### PR TITLE
Feat: Add ZkVerificationError enum for on-chain verification.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,12 +6,15 @@
     "": {
       "license": "ISC",
       "dependencies": {
-        "@coral-xyz/anchor": "^0.30.1"
+        "@coral-xyz/anchor": "^0.30.1",
+        "@solana/web3.js": "^1.87.6",
+        "bn.js": "^5.2.1"
       },
       "devDependencies": {
         "@types/bn.js": "^5.1.0",
         "@types/chai": "^4.3.0",
         "@types/mocha": "^9.0.0",
+        "@types/node": "^20.10.5",
         "chai": "^4.3.4",
         "mocha": "^9.0.3",
         "prettier": "^2.6.2",
@@ -286,12 +289,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.2.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.1.tgz",
-      "integrity": "sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==",
+      "version": "20.19.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.10.tgz",
+      "integrity": "sha512-iAFpG6DokED3roLSP0K+ybeDdIX6Bc0Vd3mLW5uDqThPWtNos3E+EqOM11mPQHKzfWHqEBuLjIlsBQQ8CsISmQ==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.10.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/uuid": {
@@ -1938,9 +1941,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
-      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
     "node_modules/utf-8-validate": {

--- a/package.json
+++ b/package.json
@@ -2,10 +2,13 @@
   "license": "ISC",  
   "scripts": {
     "lint:fix": "prettier */*.js \"*/**/*{.js,.ts}\" -w",
-    "lint": "prettier */*.js \"*/**/*{.js,.ts}\" --check"
+    "lint": "prettier */*.js \"*/**/*{.js,.ts}\" --check",
+    "test": "anchor test"
   },
   "dependencies": {
-    "@coral-xyz/anchor": "^0.30.1"
+    "@coral-xyz/anchor": "^0.30.1",
+    "@solana/web3.js": "^1.87.6",
+    "bn.js": "^5.2.1"
   },
   "devDependencies": {
     "chai": "^4.3.4",
@@ -14,6 +17,7 @@
     "@types/bn.js": "^5.1.0",
     "@types/chai": "^4.3.0",
     "@types/mocha": "^9.0.0",
+    "@types/node": "^20.10.5",
     "typescript": "^4.3.5",
     "prettier": "^2.6.2"
   }

--- a/programs/zk-verification/src/errors.rs
+++ b/programs/zk-verification/src/errors.rs
@@ -1,0 +1,29 @@
+use anchor_lang::prelude::*;
+use thiserror::Error;
+
+#[error_code]
+pub enum ZkVerificationError {
+    #[msg("Public inputs conversion failed")]
+    PublicInputsTryIntoFailed,
+    
+    #[msg("Failed to decompress G1 point")]
+    DecompressG1Failed,
+    
+    #[msg("Failed to decompress G2 point")]
+    DecompressG2Failed,
+    
+    #[msg("Invalid public inputs length")]
+    InvalidPublicInputsLength,
+    
+    #[msg("Failed to create Groth16 verifier")]
+    CreateGroth16VerifierFailed,
+    
+    #[msg("Proof verification failed")]
+    ProofVerificationFailed,
+    
+    #[msg("Invalid batch size")]
+    InvalidBatchSize,
+    
+    #[msg("Invalid proof format")]
+    InvalidProofFormat,
+}

--- a/programs/zk-verification/src/proof.rs
+++ b/programs/zk-verification/src/proof.rs
@@ -1,0 +1,42 @@
+use anchor_lang::prelude::*;
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug)]
+pub struct CompressedProof {
+    pub a: [u8; 32],
+    pub b: [u8; 64],
+    pub c: [u8; 32],
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug)]
+pub struct Groth16VerifyingKey {
+    pub alpha_g1: [u8; 32],
+    pub beta_g2: [u8; 64],
+    pub gamma_g2: [u8; 64],
+    pub delta_g2: [u8; 64],
+    pub gamma_abc_g1: Vec<[u8; 32]>,
+}
+
+#[account]
+pub struct VerifyingKeyAccount {
+    pub authority: Pubkey,
+    pub circuit_id: String,
+    pub key: Groth16VerifyingKey,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug)]
+pub struct VerificationContext {
+    pub verification_type: String,
+    pub public_inputs: Vec<[u8; 32]>,
+    pub proof: CompressedProof,
+}
+
+#[account]
+pub struct VerificationResult {
+    pub subject: Pubkey,
+    pub verifier: Pubkey,
+    pub verification_type: String,
+    pub timestamp: i64,
+    pub is_valid: bool,
+    pub commitment: Option<[u8; 32]>,
+    pub expiration: Option<i64>,
+}


### PR DESCRIPTION
This commit introduces a new ZkVerificationError enum to handle various errors that can occur during zero-knowledge proof verification on-chain. The new error codes provide clear, descriptive messages for issues such as invalid public inputs, decompression failures, and proof verification failures, improving the clarity and debuggability of the verification process.